### PR TITLE
Removing some extra labels and renaming the dyno label

### DIFF
--- a/config/grafana-agent-config.yml
+++ b/config/grafana-agent-config.yml
@@ -20,9 +20,7 @@ metrics:
             - targets:
                 - localhost:${PORT}
               labels:
-                env: ${GRAFANA_AGENT_ENV:-default}
-                heroku_app_name: ${HEROKU_APP_NAME}
-                heroku_dyno_name: ${DYNO}
+                instance: ${DYNO}
 
         - job_name: heroku_recording_service_http_metrics
           honor_labels: true
@@ -38,9 +36,7 @@ metrics:
             - targets:
                 - localhost:${PORT}
               labels:
-                env: ${GRAFANA_AGENT_ENV:-default}
-                heroku_app_name: ${HEROKU_APP_NAME}
-                heroku_dyno_name: ${DYNO}
+                instance: ${DYNO}
 
         - job_name: heroku_auth_service_http_metrics
           honor_labels: true
@@ -56,9 +52,7 @@ metrics:
             - targets:
                 - localhost:${PORT}
               labels:
-                env: ${GRAFANA_AGENT_ENV:-default}
-                heroku_app_name: ${HEROKU_APP_NAME}
-                heroku_dyno_name: ${DYNO}
+                instance: ${DYNO}
   global:
     scrape_interval: ${GRAFANA_AGENT_SCRAPE_INTERVAL:-20s}
     remote_write:


### PR DESCRIPTION
These removed labels are already included by the cypress-services apps.

The dyno label rename to `instance` prevents us from having a bogus `instance` label that prometheus auto-applies 